### PR TITLE
Update EDMC to 5.8.0

### DIFF
--- a/io.edcd.EDMarketConnector.appdata.xml
+++ b/io.edcd.EDMarketConnector.appdata.xml
@@ -10,7 +10,7 @@
     <project_license>GPL-2.0-only</project_license>
 
     <releases>
-        <release version="5.7.0" date="2022-12-16"/>
+        <release version="5.8.0" date="2023-01-20"/>
     </releases>
 
     <description>

--- a/io.edcd.EDMarketConnector.desktop
+++ b/io.edcd.EDMarketConnector.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=E:D Market Connector
-Exec=/usr/bin/python3 /app/edmarketconnector/EDMarketConnector.py
-Terminal=false
-Icon=io.edcd.EDMarketConnector
-Type=Application
-Categories=Game;
-X-Desktop-File-Install-Version=0.21

--- a/io.edcd.EDMarketConnector.yaml
+++ b/io.edcd.EDMarketConnector.yaml
@@ -27,19 +27,17 @@ modules:
       - install -dm755 ${FLATPAK_DEST}/bin
       - cp -r ${FLATPAK_BUILDER_BUILDDIR}/* ${FLATPAK_DEST}/edmarketconnector
       - install edmarketconnector.sh ${FLATPAK_DEST}/bin/edmarketconnector
-      - install -t ${FLATPAK_DEST}/share/appdata/ -Dm644 io.edcd.EDMarketConnector.appdata.xml
-      - install -t ${FLATPAK_DEST}/share/applications/ -Dm644 io.edcd.EDMarketConnector.desktop
-      - install -Dm644 ${FLATPAK_BUILDER_BUILDDIR}/EDMarketConnector.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
+      - install -t ${FLATPAK_DEST}/share/appdata/ -Dm644 ${FLATPAK_ID}.appdata.xml
+      - install -t ${FLATPAK_DEST}/share/applications/ -Dm644 ${FLATPAK_ID}.desktop
+      - install -t ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/ -Dm644 ${FLATPAK_ID}.png
     sources:
       - type: git
         url: https://github.com/EDCD/EDMarketConnector
-        tag: Release/5.7.0
+        tag: Release/5.8.0
         disable-shallow-clone: true
         x-checker-data:
           type: git
           tag-pattern: 'Release\/([\d.]+)$'
-      - type: file
-        path: io.edcd.EDMarketConnector.desktop
       - type: file
         path: io.edcd.EDMarketConnector.appdata.xml
       - type: file

--- a/python3-requirements.yaml
+++ b/python3-requirements.yaml
@@ -1,4 +1,4 @@
-# Generated with flatpak-pip-generator -r requirements.txt --checker-data --yaml
+# Generated with flatpak-pip-generator -r requirements.txt --yaml
 build-commands: []
 buildsystem: simple
 modules:
@@ -12,57 +12,42 @@ modules:
         type: file
         url: https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl
         sha256: 4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
-        x-checker-data:
-          name: certifi
-          packagetype: bdist_wheel
-          type: pypi
   - name: python3-requests
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "requests==2.28.1" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "requests==2.28.2" --no-build-isolation
     sources:
       - *id001
-      - type: file
+      - &id002
+        type: file
         url: https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl
         sha256: 83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
-        x-checker-data:
-          name: charset_normalizer
-          packagetype: bdist_wheel
-          type: pypi
       - type: file
         url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
         sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
-        x-checker-data:
-          name: idna
-          packagetype: bdist_wheel
-          type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl
-        sha256: 8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
-        x-checker-data:
-          name: requests
-          packagetype: bdist_wheel
-          type: pypi
+        url: https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl
+        sha256: 64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa
       - type: file
-        url: https://files.pythonhosted.org/packages/65/0c/cc6644eaa594585e5875f46f3c83ee8762b647b51fc5b0fb253a242df2dc/urllib3-1.26.13-py2.py3-none-any.whl
-        sha256: 47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc
-        x-checker-data:
-          name: urllib3
-          packagetype: bdist_wheel
-          type: pypi
+        url: https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl
+        sha256: 75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1
+  - name: python3-charset-normalizer
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "charset-normalizer==2.1.1" --no-build-isolation
+    sources:
+      - *id002
   - name: python3-watchdog
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "watchdog==2.2.0" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "watchdog==2.2.1" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/c3/fb/bd960970258366b0704307ccd12617d64201407bfb6d31ae412d2762ccf1/watchdog-2.2.0.tar.gz
-        sha256: 83cf8bc60d9c613b66a4c018051873d6273d9e45d040eed06d6a96241bd8ec01
-        x-checker-data:
-          name: watchdog
-          type: pypi
+        url: https://files.pythonhosted.org/packages/11/6f/0396d373e039b89c60e23a1a9025edc6dd203121fe0af7d1427e85d5ec98/watchdog-2.2.1.tar.gz
+        sha256: cdcc23c9528601a8a293eb4369cbd14f6b4f34f07ae8769421252e9c22718b6f
   - name: python3-semantic-version
     buildsystem: simple
     build-commands:
@@ -72,8 +57,4 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
         sha256: de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177
-        x-checker-data:
-          name: semantic_version
-          packagetype: bdist_wheel
-          type: pypi
 name: python3-requirements


### PR DESCRIPTION
- Use upstream release 5.8.0 of EDMarketConnector
- Remove checker-data from Python dependencies because we want to use the versions upstream uses
- Remove bundled *.desktop file and use the upstream one

Closes #3
Closes #12 