### PR TITLE
Overwrite `TMPDIR` for debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Flatpak apps store their own data in different locations than a normal app on yo
   ```plain
   ~/.var/app/io.edcd.EDMarketConnector/data/EDMarketConnector/plugins/
   ```
+
+- Debug Logs (user ID `1000` might vary):  
+
+  ```plain
+  /run/user/1000/app/io.edcd.EDMarketConnector/EDMarketConnector
+  ```

--- a/edmarketconnector.sh
+++ b/edmarketconnector.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
+
 cd /app/edmarketconnector; python3 EDMarketConnector.py


### PR DESCRIPTION
Fixes #33. The issue was that `tempfile.gettempdir()` returns `/tmp`, however that is sandboxed and not readable from the host OS, so the "open log folder" button did nothing. So we have to overwrite `TMPDIR` like suggested [here](https://docs.flatpak.org/en/latest/sandbox-permissions.html#filesystem-access).

@dvdmuckle any opinions?