### PR TITLE
Add steam flatpak permissions for journal folder

### DIFF
--- a/io.edcd.EDMarketConnector.yaml
+++ b/io.edcd.EDMarketConnector.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --share=network
   - --filesystem=~/.steam/steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved\
     Games/Frontier\ Developments/Elite\ Dangerous
-  - --filesystem=~/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved\
+  - --filesystem=~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved\
     Games/Frontier\ Developments/Elite\ Dangerous
 cleanup:
   - /man

--- a/io.edcd.EDMarketConnector.yaml
+++ b/io.edcd.EDMarketConnector.yaml
@@ -10,6 +10,8 @@ finish-args:
   - --share=network
   - --filesystem=~/.steam/steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved\
     Games/Frontier\ Developments/Elite\ Dangerous
+  - --filesystem=~/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved\
+    Games/Frontier\ Developments/Elite\ Dangerous
 cleanup:
   - /man
   - /include


### PR DESCRIPTION
Fixes #8. I do want to double check by installing Steam/Elite as a flatpak, but I don't currently have the space on my laptop, and didn't have access to my desktop at the time.