### PR TITLE
Downgrade to runtime 23.08 to get to Python 3.11

### DIFF
--- a/io.edcd.EDMarketConnector.yaml
+++ b/io.edcd.EDMarketConnector.yaml
@@ -1,6 +1,6 @@
 app-id: io.edcd.EDMarketConnector
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '23.08'
 command: edmarketconnector
 sdk: org.freedesktop.Sdk
 finish-args:


### PR DESCRIPTION
We had previously optimistically upgraded to runtime 24.08, which uses Python 3.12. However, it looks like some code changes need to happen on EDMC to properly support this version of Python. Until then, we should downgrade so we can get Python 3.11.11. It's not 3.11.9, which is what EDMC currently builds with for Windows, but it's closer that 3.12.